### PR TITLE
Updates setup-acl-rules logic

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -99,7 +99,7 @@ resource null_resource update_acl_rules {
   count = var.vpc_subnet_count > 0 && (length(var.acl_rules) > 0 || length(var.security_group_rules) > 0) ? 1 : 0
 
   provisioner "local-exec" {
-    command = "${path.module}/scripts/setup-acl-rules.sh '${data.ibm_is_subnet.subnet[0].network_acl}' '${var.region}' '${var.resource_group_id}'"
+    command = "${path.module}/scripts/setup-acl-rules.sh '${data.ibm_is_subnet.subnet[0].network_acl}' '${var.region}' '${var.resource_group_id}' '${var.target_network_range}'"
 
     environment = {
       IBMCLOUD_API_KEY = var.ibmcloud_api_key

--- a/variables.tf
+++ b/variables.tf
@@ -160,3 +160,9 @@ variable "acl_rules" {
   description = "List of rules to set on the subnet access control list"
   default = []
 }
+
+variable "target_network_range" {
+  type        = string
+  description = "The ip address range that should be used for the network acl rules generated from the security groups"
+  default     = "0.0.0.0/0"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -27,7 +27,7 @@ variable "label" {
 variable "image_name" {
   type        = string
   description = "The name of the image to use for the virtual server"
-  default     = "ibm-ubuntu-18-04-1-minimal-amd64-2"
+  default     = "ibm-ubuntu-18-04-5-minimal-amd64-1"
 }
 
 variable "vpc_subnet_count" {


### PR DESCRIPTION
- Adds module variable to set default IP range for generated access control lists from security groups
- Updates logic to generate the acl rule and an corresponding rule in the reverse direction

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>