### PR TITLE
Tag resources created in module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -70,6 +70,7 @@ resource ibm_is_security_group vsi {
   name           = "${local.name}-group"
   vpc            = data.ibm_is_vpc.vpc.id
   resource_group = var.resource_group_id
+  tags           = var.tags
 }
 
 resource ibm_is_security_group_rule additional_rules {
@@ -163,6 +164,21 @@ resource ibm_is_instance vsi {
 
   tags = var.tags
 }
+
+data "ibm_is_volume" "instance_bd" {
+  depends_on = [ ibm_is_instance.vsi ]
+
+  count = var.vpc_subnet_count
+  name  = "${local.name}${format("%02s", count.index)}-boot"
+}
+
+resource "ibm_resource_tag" "bd_tag" {
+  count      = var.vpc_subnet_count
+  
+  resource_id = data.ibm_is_volume.instance_bd[count.index].crn
+  tags        = var.tags
+}
+
 
 resource ibm_is_floating_ip vsi {
   count = var.create_public_ip ? var.vpc_subnet_count : 0

--- a/test/stages/stage1-subnets.tf
+++ b/test/stages/stage1-subnets.tf
@@ -1,7 +1,7 @@
 module "subnets" {
   source = "github.com/cloud-native-toolkit/terraform-ibm-vpc-subnets.git"
 
-  resource_group_id = module.resource_group.id
+  resource_group_name = module.resource_group.name
   region            = var.region
   vpc_name          = module.vpc.name
   gateways          = []

--- a/test/stages/stage1-vpc.tf
+++ b/test/stages/stage1-vpc.tf
@@ -1,7 +1,6 @@
 module "vpc" {
   source = "github.com/cloud-native-toolkit/terraform-ibm-vpc.git"
 
-  resource_group_id   = module.resource_group.id
   resource_group_name = module.resource_group.name
   region              = var.region
   name_prefix         = var.name_prefix


### PR DESCRIPTION
* Updates `main.tf` to tag the security group and boot volume associated with the instance. Module currently only tags vsi instance.

* Updates to tests to use `resource_group_name` for compatibility with VPC change: https://github.com/cloud-native-toolkit/terraform-ibm-vpc/commit/3a937194c5177b2376f576e27397c83baf269b35